### PR TITLE
Feature/jst 396/better passphrase handling

### DIFF
--- a/src/manifest/manifest-sign.action.ts
+++ b/src/manifest/manifest-sign.action.ts
@@ -14,7 +14,7 @@ export async function manifestSignAction(options: ManifestSignOptions): Promise<
   const manifestBase64 = manifestBuffer.toString("base64");
 
   const keyFile = await readFile(options.keyFile);
-  let passphraseRequired = keyFile.toString("ascii").includes("BEGIN ENCRYPTED PRIVATE KEY");
+  const passphraseRequired = keyFile.toString("ascii").includes("BEGIN ENCRYPTED PRIVATE KEY");
 
   if (passphraseRequired && !options.passphrase) {
     console.error("Error: Private key file is encrypted and no passphrase was provided. Use --passphrase option.");


### PR DESCRIPTION
Changes:
- if key is encrypted, passphrase is required
- if key is not encrypted, fail if passphrase is provided
- if key is invalid, print a meaningful error message
- if passphrase is invalid, print meaningful error message.