### PR TITLE
Update to golem-js 3.0

### DIFF
--- a/data/project-templates/js-node-esm/package.json
+++ b/data/project-templates/js-node-esm/package.json
@@ -16,7 +16,7 @@
     "application"
   ],
   "dependencies": {
-    "@golem-sdk/golem-js": "^3.0.0-beta.44",
+    "@golem-sdk/golem-js": "^3.0.0-beta.51",
     "dotenv": "^16.4.5"
   }
 }

--- a/data/project-templates/js-node-esm/package.json
+++ b/data/project-templates/js-node-esm/package.json
@@ -16,7 +16,7 @@
     "application"
   ],
   "dependencies": {
-    "@golem-sdk/golem-js": "^3.0.0-beta.51",
+    "@golem-sdk/golem-js": "^3.0.0",
     "dotenv": "^16.4.5"
   }
 }

--- a/data/project-templates/js-node-esm/src/index.js
+++ b/data/project-templates/js-node-esm/src/index.js
@@ -6,8 +6,8 @@ const order = {
     workload: { imageTag: "golem/alpine:latest" },
   },
   market: {
-    // 5 minutes
-    rentHours: 5 / 60,
+    // 15 minutes
+    rentHours: 15 / 60,
     pricing: {
       model: "linear",
       maxStartPrice: 0.5,
@@ -24,9 +24,10 @@ const order = {
     await glm.connect();
     // create a pool that can grow up to 3 rentals at the same time
     const pool = await glm.manyOf({
-      concurrency: 3,
+      poolSize: 3,
       order,
     });
+    console.log("Starting work on Golem!");
     await Promise.allSettled([
       pool.withRental(async (rental) =>
         rental

--- a/data/project-templates/js-node-esm/src/index.js
+++ b/data/project-templates/js-node-esm/src/index.js
@@ -22,26 +22,26 @@ const order = {
 
   try {
     await glm.connect();
-    // create a pool that can grow up to 3 leases at the same time
+    // create a pool that can grow up to 3 rentals at the same time
     const pool = await glm.manyOf({
       concurrency: 3,
       order,
     });
     await Promise.allSettled([
-      pool.withLease(async (lease) =>
-        lease
+      pool.withRental(async (rental) =>
+        rental
           .getExeUnit()
           .then((exe) => exe.run("echo Hello, Golem from the first machine! 👋"))
           .then((res) => console.log(res.stdout)),
       ),
-      pool.withLease(async (lease) =>
-        lease
+      pool.withRental(async (rental) =>
+        rental
           .getExeUnit()
           .then((exe) => exe.run("echo Hello, Golem from the second machine! 👋"))
           .then((res) => console.log(res.stdout)),
       ),
-      pool.withLease(async (lease) =>
-        lease
+      pool.withRental(async (rental) =>
+        rental
           .getExeUnit()
           .then((exe) => exe.run("echo Hello, Golem from the third machine! 👋"))
           .then((res) => console.log(res.stdout)),

--- a/data/project-templates/js-node/package.json
+++ b/data/project-templates/js-node/package.json
@@ -15,7 +15,7 @@
     "application"
   ],
   "dependencies": {
-    "@golem-sdk/golem-js": "^3.0.0-beta.44",
+    "@golem-sdk/golem-js": "^3.0.0-beta.51",
     "dotenv": "^16.4.5"
   }
 }

--- a/data/project-templates/js-node/package.json
+++ b/data/project-templates/js-node/package.json
@@ -15,7 +15,7 @@
     "application"
   ],
   "dependencies": {
-    "@golem-sdk/golem-js": "^3.0.0-beta.51",
+    "@golem-sdk/golem-js": "^3.0.0",
     "dotenv": "^16.4.5"
   }
 }

--- a/data/project-templates/js-node/src/index.js
+++ b/data/project-templates/js-node/src/index.js
@@ -6,8 +6,8 @@ const order = {
     workload: { imageTag: "golem/alpine:latest" },
   },
   market: {
-    // 5 minutes
-    rentHours: 5 / 60,
+    // 15 minutes
+    rentHours: 15 / 60,
     pricing: {
       model: "linear",
       maxStartPrice: 0.5,
@@ -24,9 +24,10 @@ const order = {
     await glm.connect();
     // create a pool that can grow up to 3 rentals at the same time
     const pool = await glm.manyOf({
-      concurrency: 3,
+      poolSize: 3,
       order,
     });
+    console.log("Starting work on Golem!");
     await Promise.allSettled([
       pool.withRental(async (rental) =>
         rental

--- a/data/project-templates/js-node/src/index.js
+++ b/data/project-templates/js-node/src/index.js
@@ -22,26 +22,26 @@ const order = {
 
   try {
     await glm.connect();
-    // create a pool that can grow up to 3 leases at the same time
+    // create a pool that can grow up to 3 rentals at the same time
     const pool = await glm.manyOf({
       concurrency: 3,
       order,
     });
     await Promise.allSettled([
-      pool.withLease(async (lease) =>
-        lease
+      pool.withRental(async (rental) =>
+        rental
           .getExeUnit()
           .then((exe) => exe.run("echo Hello, Golem from the first machine! 👋"))
           .then((res) => console.log(res.stdout)),
       ),
-      pool.withLease(async (lease) =>
-        lease
+      pool.withRental(async (rental) =>
+        rental
           .getExeUnit()
           .then((exe) => exe.run("echo Hello, Golem from the second machine! 👋"))
           .then((res) => console.log(res.stdout)),
       ),
-      pool.withLease(async (lease) =>
-        lease
+      pool.withRental(async (rental) =>
+        rental
           .getExeUnit()
           .then((exe) => exe.run("echo Hello, Golem from the third machine! 👋"))
           .then((res) => console.log(res.stdout)),

--- a/data/project-templates/react-js/package.json
+++ b/data/project-templates/react-js/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@golem-sdk/golem-js": "^3.0.0-beta.44",
+    "@golem-sdk/golem-js": "^3.0.0-beta.51",
     "@golem-sdk/react": "^3.0.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/data/project-templates/react-js/package.json
+++ b/data/project-templates/react-js/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@golem-sdk/golem-js": "^3.0.0-beta.51",
+    "@golem-sdk/golem-js": "^3.0.0",
     "@golem-sdk/react": "^3.0.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/data/project-templates/react-ts/package.json
+++ b/data/project-templates/react-ts/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@golem-sdk/golem-js": "^3.0.0-beta.44",
+    "@golem-sdk/golem-js": "^3.0.0-beta.51",
     "@golem-sdk/react": "^3.0.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/data/project-templates/react-ts/package.json
+++ b/data/project-templates/react-ts/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@golem-sdk/golem-js": "^3.0.0-beta.51",
+    "@golem-sdk/golem-js": "^3.0.0",
     "@golem-sdk/react": "^3.0.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/data/project-templates/ts-node-esm/package.json
+++ b/data/project-templates/ts-node-esm/package.json
@@ -18,7 +18,7 @@
     "application"
   ],
   "dependencies": {
-    "@golem-sdk/golem-js": "^3.0.0-beta.51",
+    "@golem-sdk/golem-js": "^3.0.0",
     "dotenv": "^16.4.5"
   }
 }

--- a/data/project-templates/ts-node-esm/package.json
+++ b/data/project-templates/ts-node-esm/package.json
@@ -18,7 +18,7 @@
     "application"
   ],
   "dependencies": {
-    "@golem-sdk/golem-js": "^3.0.0-beta.44",
+    "@golem-sdk/golem-js": "^3.0.0-beta.51",
     "dotenv": "^16.4.5"
   }
 }

--- a/data/project-templates/ts-node-esm/src/index.ts
+++ b/data/project-templates/ts-node-esm/src/index.ts
@@ -22,26 +22,26 @@ const order: MarketOrderSpec = {
 
   try {
     await glm.connect();
-    // create a pool that can grow up to 3 leases at the same time
+    // create a pool that can grow up to 3 rentals at the same time
     const pool = await glm.manyOf({
       concurrency: 3,
       order,
     });
     await Promise.allSettled([
-      pool.withLease(async (lease) =>
-        lease
+      pool.withRental(async (rental) =>
+        rental
           .getExeUnit()
           .then((exe) => exe.run("echo Hello, Golem from the first machine! 👋"))
           .then((res) => console.log(res.stdout)),
       ),
-      pool.withLease(async (lease) =>
-        lease
+      pool.withRental(async (rental) =>
+        rental
           .getExeUnit()
           .then((exe) => exe.run("echo Hello, Golem from the second machine! 👋"))
           .then((res) => console.log(res.stdout)),
       ),
-      pool.withLease(async (lease) =>
-        lease
+      pool.withRental(async (rental) =>
+        rental
           .getExeUnit()
           .then((exe) => exe.run("echo Hello, Golem from the third machine! 👋"))
           .then((res) => console.log(res.stdout)),

--- a/data/project-templates/ts-node-esm/src/index.ts
+++ b/data/project-templates/ts-node-esm/src/index.ts
@@ -6,8 +6,8 @@ const order: MarketOrderSpec = {
     workload: { imageTag: "golem/alpine:latest" },
   },
   market: {
-    // 5 minutes
-    rentHours: 5 / 60,
+    // 15 minutes
+    rentHours: 15 / 60,
     pricing: {
       model: "linear",
       maxStartPrice: 0.5,
@@ -24,9 +24,10 @@ const order: MarketOrderSpec = {
     await glm.connect();
     // create a pool that can grow up to 3 rentals at the same time
     const pool = await glm.manyOf({
-      concurrency: 3,
+      poolSize: 3,
       order,
     });
+    console.log("Starting work on Golem!");
     await Promise.allSettled([
       pool.withRental(async (rental) =>
         rental

--- a/data/project-templates/ts-node-esm/tsconfig.json
+++ b/data/project-templates/ts-node-esm/tsconfig.json
@@ -1,109 +1,18 @@
 {
   "compilerOptions": {
-    /* Visit https://aka.ms/tsconfig to read more about this file */
-
-    /* Projects */
-    // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
-    // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
-    // "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
-    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
-    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
-    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
-
-    /* Language and Environment */
-    "target": "es2016" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
-    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
-    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
-    // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
-    // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
-    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
-    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
-    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
-    // "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
-    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
-    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
-    // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
-
-    /* Modules */
-    "module": "NodeNext" /* Specify what module code is generated. */,
-    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
-    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
-    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
-    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
-    // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
-    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
-    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
-    // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
-    // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */
-    // "resolvePackageJsonExports": true,                /* Use the package.json 'exports' field when resolving package imports. */
-    // "resolvePackageJsonImports": true,                /* Use the package.json 'imports' field when resolving imports. */
-    // "customConditions": [],                           /* Conditions to set in addition to the resolver-specific defaults when resolving imports. */
-    // "resolveJsonModule": true,                        /* Enable importing .json files. */
-    // "allowArbitraryExtensions": true,                 /* Enable importing files with any extension, provided a declaration file is present. */
-    // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
-
-    /* JavaScript Support */
-    // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
-    // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
-    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
-
-    /* Emit */
-    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
-    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
-    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
-    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
-    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
-    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-    "outDir": "./dist" /* Specify an output folder for all emitted files. */,
-    // "removeComments": true,                           /* Disable emitting comments. */
-    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
-    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
-    // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */
-    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
-    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
-    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
-    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
-    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
-    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
-    // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
-    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
-    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
-    // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
-    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
-    // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
-
-    /* Interop Constraints */
-    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
-    // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
-    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
-    "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
-    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
-    "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
-
-    /* Type Checking */
-    "strict": true /* Enable all strict type-checking options. */,
-    // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
-    // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
-    // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
-    // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
-    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
-    // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
-    // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
-    // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
-    // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
-    // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
-    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
-    // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
-    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
-    // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
-    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
-    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
-    // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
-    // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
-
-    /* Completeness */
-    // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
-    "skipLibCheck": true /* Skip type checking all .d.ts files. */
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "target": "es2022",
+    "allowJs": true,
+    "resolveJsonModule": true,
+    "moduleDetection": "force",
+    "isolatedModules": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "module": "NodeNext",
+    "outDir": "dist",
+    "sourceMap": true,
+    "lib": ["es2022"]
   }
 }

--- a/data/project-templates/ts-node/package.json
+++ b/data/project-templates/ts-node/package.json
@@ -18,7 +18,7 @@
     "application"
   ],
   "dependencies": {
-    "@golem-sdk/golem-js": "^3.0.0-beta.51",
+    "@golem-sdk/golem-js": "^3.0.0",
     "dotenv": "^16.4.5"
   }
 }

--- a/data/project-templates/ts-node/package.json
+++ b/data/project-templates/ts-node/package.json
@@ -18,7 +18,7 @@
     "application"
   ],
   "dependencies": {
-    "@golem-sdk/golem-js": "^3.0.0-beta.44",
+    "@golem-sdk/golem-js": "^3.0.0-beta.51",
     "dotenv": "^16.4.5"
   }
 }

--- a/data/project-templates/ts-node/src/index.ts
+++ b/data/project-templates/ts-node/src/index.ts
@@ -22,26 +22,26 @@ const order: MarketOrderSpec = {
 
   try {
     await glm.connect();
-    // create a pool that can grow up to 3 leases at the same time
+    // create a pool that can grow up to 3 rentals at the same time
     const pool = await glm.manyOf({
       concurrency: 3,
       order,
     });
     await Promise.allSettled([
-      pool.withLease(async (lease) =>
-        lease
+      pool.withRental(async (rental) =>
+        rental
           .getExeUnit()
           .then((exe) => exe.run("echo Hello, Golem from the first machine! 👋"))
           .then((res) => console.log(res.stdout)),
       ),
-      pool.withLease(async (lease) =>
-        lease
+      pool.withRental(async (rental) =>
+        rental
           .getExeUnit()
           .then((exe) => exe.run("echo Hello, Golem from the second machine! 👋"))
           .then((res) => console.log(res.stdout)),
       ),
-      pool.withLease(async (lease) =>
-        lease
+      pool.withRental(async (rental) =>
+        rental
           .getExeUnit()
           .then((exe) => exe.run("echo Hello, Golem from the third machine! 👋"))
           .then((res) => console.log(res.stdout)),

--- a/data/project-templates/ts-node/src/index.ts
+++ b/data/project-templates/ts-node/src/index.ts
@@ -6,8 +6,8 @@ const order: MarketOrderSpec = {
     workload: { imageTag: "golem/alpine:latest" },
   },
   market: {
-    // 5 minutes
-    rentHours: 5 / 60,
+    // 15 minutes
+    rentHours: 15 / 60,
     pricing: {
       model: "linear",
       maxStartPrice: 0.5,
@@ -24,9 +24,10 @@ const order: MarketOrderSpec = {
     await glm.connect();
     // create a pool that can grow up to 3 rentals at the same time
     const pool = await glm.manyOf({
-      concurrency: 3,
+      poolSize: 3,
       order,
     });
+    console.log("Starting work on Golem!");
     await Promise.allSettled([
       pool.withRental(async (rental) =>
         rental

--- a/data/project-templates/ts-node/tsconfig.json
+++ b/data/project-templates/ts-node/tsconfig.json
@@ -1,109 +1,18 @@
 {
   "compilerOptions": {
-    /* Visit https://aka.ms/tsconfig to read more about this file */
-
-    /* Projects */
-    // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
-    // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
-    // "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
-    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
-    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
-    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
-
-    /* Language and Environment */
-    "target": "es2016" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
-    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
-    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
-    // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
-    // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
-    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
-    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
-    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
-    // "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
-    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
-    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
-    // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
-
-    /* Modules */
-    "module": "NodeNext" /* Specify what module code is generated. */,
-    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
-    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
-    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
-    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
-    // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
-    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
-    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
-    // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
-    // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */
-    // "resolvePackageJsonExports": true,                /* Use the package.json 'exports' field when resolving package imports. */
-    // "resolvePackageJsonImports": true,                /* Use the package.json 'imports' field when resolving imports. */
-    // "customConditions": [],                           /* Conditions to set in addition to the resolver-specific defaults when resolving imports. */
-    // "resolveJsonModule": true,                        /* Enable importing .json files. */
-    // "allowArbitraryExtensions": true,                 /* Enable importing files with any extension, provided a declaration file is present. */
-    // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
-
-    /* JavaScript Support */
-    // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
-    // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
-    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
-
-    /* Emit */
-    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
-    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
-    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
-    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
-    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
-    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-    "outDir": "./dist" /* Specify an output folder for all emitted files. */,
-    // "removeComments": true,                           /* Disable emitting comments. */
-    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
-    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
-    // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */
-    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
-    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
-    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
-    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
-    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
-    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
-    // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
-    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
-    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
-    // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
-    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
-    // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
-
-    /* Interop Constraints */
-    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
-    // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
-    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
-    "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
-    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
-    "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
-
-    /* Type Checking */
-    "strict": true /* Enable all strict type-checking options. */,
-    // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
-    // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
-    // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
-    // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
-    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
-    // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
-    // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
-    // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
-    // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
-    // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
-    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
-    // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
-    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
-    // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
-    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
-    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
-    // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
-    // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
-
-    /* Completeness */
-    // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
-    "skipLibCheck": true /* Skip type checking all .d.ts files. */
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "target": "es2022",
+    "allowJs": true,
+    "resolveJsonModule": true,
+    "moduleDetection": "force",
+    "isolatedModules": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "module": "NodeNext",
+    "outDir": "dist",
+    "sourceMap": true,
+    "lib": ["es2022"]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@golem-sdk/golem-js": "^3.0.0-beta.44",
+        "@golem-sdk/golem-js": "^3.0.0-beta.51",
         "dotenv": "^16.4.5"
       }
     },
@@ -68,7 +68,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@golem-sdk/golem-js": "^3.0.0-beta.44",
+        "@golem-sdk/golem-js": "^3.0.0-beta.51",
         "dotenv": "^16.4.5"
       }
     },
@@ -76,7 +76,7 @@
       "name": "react-js-golem-app",
       "version": "0.0.0",
       "dependencies": {
-        "@golem-sdk/golem-js": "^3.0.0-beta.44",
+        "@golem-sdk/golem-js": "^3.0.0-beta.51",
         "@golem-sdk/react": "^3.0.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
@@ -96,7 +96,7 @@
       "name": "react-ts-golem-app",
       "version": "0.0.0",
       "dependencies": {
-        "@golem-sdk/golem-js": "^3.0.0-beta.44",
+        "@golem-sdk/golem-js": "^3.0.0-beta.51",
         "@golem-sdk/react": "^3.0.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
@@ -119,7 +119,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@golem-sdk/golem-js": "^3.0.0-beta.44",
+        "@golem-sdk/golem-js": "^3.0.0-beta.51",
         "dotenv": "^16.4.5"
       }
     },
@@ -128,7 +128,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@golem-sdk/golem-js": "^3.0.0-beta.44",
+        "@golem-sdk/golem-js": "^3.0.0-beta.51",
         "dotenv": "^16.4.5"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@golem-sdk/golem-js": "^3.0.0-beta.51",
+        "@golem-sdk/golem-js": "^3.0.0",
         "dotenv": "^16.4.5"
       }
     },
@@ -68,7 +68,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@golem-sdk/golem-js": "^3.0.0-beta.51",
+        "@golem-sdk/golem-js": "^3.0.0",
         "dotenv": "^16.4.5"
       }
     },
@@ -76,7 +76,7 @@
       "name": "react-js-golem-app",
       "version": "0.0.0",
       "dependencies": {
-        "@golem-sdk/golem-js": "^3.0.0-beta.51",
+        "@golem-sdk/golem-js": "^3.0.0",
         "@golem-sdk/react": "^3.0.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
@@ -96,7 +96,7 @@
       "name": "react-ts-golem-app",
       "version": "0.0.0",
       "dependencies": {
-        "@golem-sdk/golem-js": "^3.0.0-beta.51",
+        "@golem-sdk/golem-js": "^3.0.0",
         "@golem-sdk/react": "^3.0.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
@@ -119,7 +119,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@golem-sdk/golem-js": "^3.0.0-beta.51",
+        "@golem-sdk/golem-js": "^3.0.0",
         "dotenv": "^16.4.5"
       }
     },
@@ -128,7 +128,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@golem-sdk/golem-js": "^3.0.0-beta.51",
+        "@golem-sdk/golem-js": "^3.0.0",
         "dotenv": "^16.4.5"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "data/project-templates/*"
       ],
       "dependencies": {
-        "@golem-sdk/golem-js": "^3.0.0-beta.51",
+        "@golem-sdk/golem-js": "^3.0.0",
         "ajv": "^8.12.0",
         "ajv-formats": "^2.1.1",
         "chalk": "4.1.2",
@@ -2096,9 +2096,9 @@
       }
     },
     "node_modules/@golem-sdk/golem-js": {
-      "version": "3.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@golem-sdk/golem-js/-/golem-js-3.0.0-beta.51.tgz",
-      "integrity": "sha512-6VMeMbuU7JSQlvtqbvqtfhJFmXR6kYQ33O6ssvbMX3N4lPnnuD+i5Mx9OK0I1af4xGDJse82M8kL24J2fncwXg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@golem-sdk/golem-js/-/golem-js-3.0.0.tgz",
+      "integrity": "sha512-jqjV+egfTIgkNQL3aGh4gorj+K9yD4/BokZ4FdT8C8LX7gkRrPSwT5OJcWUrt/Qq03aDI5J4FuOeN8RLWOiWAw==",
       "dependencies": {
         "async-lock": "^1.4.1",
         "async-retry": "^1.3.3",
@@ -2114,9 +2114,9 @@
         "rxjs": "^7.8.1",
         "semver": "^7.5.4",
         "tmp": "^0.2.2",
-        "uuid": "^9.0.1",
+        "uuid": "^10.0.0",
         "ws": "^8.16.0",
-        "ya-ts-client": "^1.1.2"
+        "ya-ts-client": "^1.1.3"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -2131,6 +2131,18 @@
       "version": "24.3.25",
       "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-24.3.25.tgz",
       "integrity": "sha512-3HDgPbgiwWMI9zVB7VYBHaMrbOO7Gm0v+yD2FV/sCKj+9NDeVL7BOBYUuhWAQGKWOzBo8S9WdMvV0eixO233XQ=="
+    },
+    "node_modules/@golem-sdk/golem-js/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/@golem-sdk/react": {
       "version": "3.0.1",
@@ -14681,9 +14693,9 @@
       }
     },
     "node_modules/ya-ts-client": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/ya-ts-client/-/ya-ts-client-1.1.2.tgz",
-      "integrity": "sha512-rZ2YMs3ATOzkaRo7NXDuNZ9xhjxufD/FLFpEm88LqnrpNJcRa81ZXy7B0yKQ2PaOedaKWELPjwcF7RoaOp2N1A==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/ya-ts-client/-/ya-ts-client-1.1.3.tgz",
+      "integrity": "sha512-30l0EAz8E1G0JbhNj8aNQF1/g9SVXYUebdVJ248jQEA8oOwxotcw2STvAZZPX84KhbKRe1W5H+rY5cnwTLzCLQ==",
       "engines": {
         "node": ">=18.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "data/project-templates/*"
       ],
       "dependencies": {
-        "@golem-sdk/golem-js": "^3.0.0-beta.45",
+        "@golem-sdk/golem-js": "^3.0.0-beta.51",
         "ajv": "^8.12.0",
         "ajv-formats": "^2.1.1",
         "chalk": "4.1.2",
@@ -2096,9 +2096,9 @@
       }
     },
     "node_modules/@golem-sdk/golem-js": {
-      "version": "3.0.0-beta.45",
-      "resolved": "https://registry.npmjs.org/@golem-sdk/golem-js/-/golem-js-3.0.0-beta.45.tgz",
-      "integrity": "sha512-Vtx3u2aqTi8zIn+LCUYCYaRu1Q2wyuNadEgWiRg1Z2Z1HlK4jNVwCTyokTJkrkcL2ikyhP66Ls/hQnOV6jSJTw==",
+      "version": "3.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@golem-sdk/golem-js/-/golem-js-3.0.0-beta.51.tgz",
+      "integrity": "sha512-6VMeMbuU7JSQlvtqbvqtfhJFmXR6kYQ33O6ssvbMX3N4lPnnuD+i5Mx9OK0I1af4xGDJse82M8kL24J2fncwXg==",
       "dependencies": {
         "async-lock": "^1.4.1",
         "async-retry": "^1.3.3",
@@ -2116,7 +2116,7 @@
         "tmp": "^0.2.2",
         "uuid": "^9.0.1",
         "ws": "^8.16.0",
-        "ya-ts-client": "^1.1.1-beta.1"
+        "ya-ts-client": "^1.1.2"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -14681,9 +14681,9 @@
       }
     },
     "node_modules/ya-ts-client": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ya-ts-client/-/ya-ts-client-1.1.1.tgz",
-      "integrity": "sha512-luRbCSoDsWFUS9D41RbeNhFBH7Rm7exmhW2R8NgtIphhCFzDfpNUD5d1R7OybWdvW50eind3ZigqaXK54zhIbQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/ya-ts-client/-/ya-ts-client-1.1.2.tgz",
+      "integrity": "sha512-rZ2YMs3ATOzkaRo7NXDuNZ9xhjxufD/FLFpEm88LqnrpNJcRa81ZXy7B0yKQ2PaOedaKWELPjwcF7RoaOp2N1A==",
       "engines": {
         "node": ">=18.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@golem-sdk/golem-js": "^3.0.0-beta.51",
+    "@golem-sdk/golem-js": "^3.0.0",
     "ajv": "^8.12.0",
     "ajv-formats": "^2.1.1",
     "chalk": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@golem-sdk/golem-js": "^3.0.0-beta.45",
+    "@golem-sdk/golem-js": "^3.0.0-beta.51",
     "ajv": "^8.12.0",
     "ajv-formats": "^2.1.1",
     "chalk": "4.1.2",

--- a/src/market/market.command.ts
+++ b/src/market/market.command.ts
@@ -1,7 +1,7 @@
 import { Command, Option } from "commander";
-import { GolemNetwork, MarketOrderSpec, OfferProposal, OfferProposalFilterFactory } from "@golem-sdk/golem-js";
+import { GolemNetwork, ScanOptions, ScannedOffer } from "@golem-sdk/golem-js";
 import chalk from "chalk";
-import { switchMap, filter, scan, takeUntil, timer, last } from "rxjs";
+import { filter, takeUntil, timer, toArray } from "rxjs";
 
 export const marketCommand = new Command("market");
 
@@ -16,16 +16,17 @@ type MarketScanOptions = {
   paymentNetwork: string;
   paymentDriver: string;
   subnetTag: string;
-  image: string;
-  minCpuCores: string;
-  minCpuThreads: string;
-  minMemGib: string;
-  minStorageGib: string;
-  maxStartPrice: string;
-  maxCpuPerHourPrice: string;
-  maxEnvPerHourPrice: string;
-  engine: string;
-  capabilities: string[];
+  engine?: string;
+  capabilities?: string[];
+  minMemGib?: string;
+  maxMemGib?: string;
+  minStorageGib?: string;
+  maxStorageGib?: string;
+  minCpuThreads?: string;
+  maxCpuThreads?: string;
+  minCpuCores?: string;
+  maxCpuCores?: string;
+  maxHourPrice?: string;
   providerId?: string[];
   providerName?: string[];
   providerWallet?: string[];
@@ -38,18 +39,22 @@ marketCommand
   .description("Runs a scan of the market with your criteria and presents results")
   .addOption(new Option("-k, --yagna-appkey <key>", "Yagna app key to use").env("YAGNA_APPKEY").makeOptionMandatory())
   .option("--yagna-url <url>", "Yagna API URL", "http://127.0.0.1:7465")
-  .option("-t, --scan-time <sec>", "Number of seconds to scan the market", "30")
+  .option("-t, --scan-time <sec>", "Number of seconds to scan the market", "10")
   .option("--payment-network <name>", "The payment network to use", "polygon")
   .option("--payment-driver <name>", "The payment driver to use", "erc20")
   .option("--subnet-tag <name>", "The Golem Network's subnet to use", "public")
-  .option("--image <name>", "The Golem Registry image to use for the query", "golem/node:20-alpine")
-  .option("--min-cpu-cores <c>", "The minimal number of CPU cores to look for", "1")
-  .option("--min-cpu-threads <t>", "The minimal number of CPU threads to look for", "1")
-  .option("--min-mem-gib <m>", "The minimal memory size to look for", "0.5")
-  .option("--min-storage-gib <s>", "The minimal storage size to look for", "0.5")
-  .option("--max-start-price <sp>", "The max start price you're willing to pay (in GLM)", "10")
-  .option("--max-cpu-per-hour-price <sp>", "The max ENV price you're willing to pay (in GLM)", "10")
-  .option("--max-env-per-hour-price <sp>", "The max CPU time price you're willing to pay (in GLM/h)", "10")
+  .option("--min-cpu-cores <c>", "The minimal number of CPU cores to look for")
+  .option("--max-cpu-cores <c>", "The maximum number of CPU cores to look for")
+  .option("--min-cpu-threads <t>", "The minimal number of CPU threads to look for")
+  .option("--max-cpu-threads <t>", "The maximum number of CPU threads to look for")
+  .option("--min-mem-gib <m>", "The minimal memory size to look for")
+  .option("--max-mem-gib <m>", "The maximum memory size to look for")
+  .option("--min-storage-gib <s>", "The minimal storage size to look for")
+  .option("--max-storage-gib <s>", "The maximum storage size to look for")
+  .option(
+    "--max-hour-price <price>",
+    "The maximum price per hour of work to look for (start price + CPU/sec * 3600 + env/sec * 3600)",
+  )
   .option("--engine <type>", "The runtime that you are interested in", "vm")
   .option("--capabilities [capabilities...]", "List of capabilities listed in the offers", [])
   .option("--provider-id [id...]", "Filter the results to only include proposals from providers with the given ids")
@@ -69,17 +74,17 @@ marketCommand
     const paymentNetwork = options.paymentNetwork;
     const paymentDriver = options.paymentDriver;
 
-    const maxStartPrice = parseFloat(options.maxStartPrice);
-    const maxCpuPerHourPrice = parseFloat(options.maxCpuPerHourPrice);
-    const maxEnvPerHourPrice = parseFloat(options.maxEnvPerHourPrice);
-
     const subnetTag = options.subnetTag;
 
-    const imageTag = options.image;
-    const minCpuCores = parseInt(options.minCpuCores);
-    const minCpuThreads = parseInt(options.minCpuThreads);
-    const minMemGib = parseFloat(options.minMemGib);
-    const minStorageGib = parseFloat(options.minStorageGib);
+    const minCpuCores = options.minCpuCores !== undefined ? parseInt(options.minCpuCores) : undefined;
+    const maxCpuCores = options.maxCpuCores !== undefined ? parseInt(options.maxCpuCores) : undefined;
+    const minCpuThreads = options.minCpuThreads !== undefined ? parseInt(options.minCpuThreads) : undefined;
+    const maxCpuThreads = options.maxCpuThreads !== undefined ? parseInt(options.maxCpuThreads) : undefined;
+    const minMemGib = options.minMemGib !== undefined ? parseFloat(options.minMemGib) : undefined;
+    const maxMemGib = options.maxMemGib !== undefined ? parseFloat(options.maxMemGib) : undefined;
+    const minStorageGib = options.minStorageGib !== undefined ? parseFloat(options.minStorageGib) : undefined;
+    const maxStorageGib = options.maxStorageGib !== undefined ? parseFloat(options.maxStorageGib) : undefined;
+    const maxHourPrice = options.maxHourPrice !== undefined ? parseFloat(options.maxHourPrice) : undefined;
     const engine = options.engine;
     const capabilities = options.capabilities;
     const providerIdFilter = (id: string) => (options.providerId ? options.providerId.includes(id) : true);
@@ -95,30 +100,22 @@ marketCommand
       console.log("Payment network and driver:", paymentNetwork, paymentDriver);
       console.log("Golem engine:", engine);
       console.log("Provider capabilities:", capabilities);
-      console.log(
-        "Requirements for image '%s', %d cores, %d threads, %dGiB of memory, %dGiB of storage",
-        imageTag,
-        minCpuCores,
-        minCpuThreads,
-        minMemGib,
-        minStorageGib,
-      );
-      console.log(
-        "Price limitations: max start price %d GLM, max CPU price %d GLM/h, max ENV price %d, GLM/h",
-        maxStartPrice.toFixed(4),
-        maxCpuPerHourPrice.toFixed(4),
-        maxEnvPerHourPrice.toFixed(4),
-      );
+      console.log("Requirements:");
+      if (minCpuCores) console.log("  - Minimum number of CPU cores:", minCpuCores);
+      if (maxCpuCores) console.log("  - Maximum number of CPU cores:", maxCpuCores);
+      if (minCpuThreads) console.log("  - Minimum number of CPU threads:", minCpuThreads);
+      if (maxCpuThreads) console.log("  - Maximum number of CPU threads:", maxCpuThreads);
+      if (minMemGib) console.log("  - Minimum memory size:", minMemGib);
+      if (maxMemGib) console.log("  - Maximum memory size:", maxMemGib);
+      if (minStorageGib) console.log("  - Minimum storage size:", minStorageGib);
+      if (maxStorageGib) console.log("  - Maximum storage size:", maxStorageGib);
+      if (maxHourPrice) console.log("  - Maximum price per hour:", maxHourPrice);
     }
 
     const glm = new GolemNetwork({
       api: {
         key: options.yagnaAppkey,
         url: options.yagnaUrl,
-      },
-      payment: {
-        driver: paymentDriver,
-        network: paymentNetwork,
       },
     });
 
@@ -134,82 +131,69 @@ marketCommand
       return;
     }
 
-    const priceLimiter = OfferProposalFilterFactory.limitPriceFilter({
-      start: maxStartPrice,
-      cpuPerSec: maxCpuPerHourPrice / 3600,
-      envPerSec: maxEnvPerHourPrice / 3600,
-    });
-
-    const scanningFilter = (p: OfferProposal) => {
-      const withinPriceRange = priceLimiter(p);
-      const isValidProviderId = providerIdFilter(p.provider.id);
-      const isValidProviderName = providerNameFilter(p.provider.name);
-      const isValidProviderWallet = providerWalletFilter(p.provider.walletAddress);
-
-      return withinPriceRange && isValidProviderId && isValidProviderName && isValidProviderWallet;
+    const priceFilter = (offer: ScannedOffer) => {
+      if (!maxHourPrice) {
+        return true;
+      }
+      const hourlyPrice = offer.pricing.start + offer.pricing.cpuSec * 3600 + offer.pricing.envSec * 3600;
+      return hourlyPrice <= maxHourPrice;
     };
 
-    const order: MarketOrderSpec = {
-      demand: {
-        subnetTag,
-        workload: {
-          imageTag,
-          minCpuCores,
-          minCpuThreads,
-          minMemGib,
-          minStorageGib,
-          capabilities,
-          engine,
-        },
+    const scanOptions: ScanOptions = {
+      workload: {
+        capabilities,
+        engine,
+        maxCpuCores,
+        maxCpuThreads,
+        maxMemGib,
+        maxStorageGib,
+        minCpuCores,
+        minCpuThreads,
+        minMemGib,
+        minStorageGib,
       },
-      market: {
-        rentHours: scanTime / 3600,
-        pricing: {
-          model: "linear",
-          maxCpuPerHourPrice,
-          maxEnvPerHourPrice,
-          maxStartPrice,
-        },
-        offerProposalFilter: scanningFilter,
+      payment: {
+        network: paymentNetwork,
+        driver: paymentDriver,
       },
+      subnetTag,
     };
 
-    const allocation = await glm.payment.createAllocation({
-      budget: 0,
-      expirationSec: scanTime,
-    });
-    const demandSpec = await glm.market.buildDemandDetails(order.demand, order.market, allocation);
+    const scanSpecification = glm.market.buildScanSpecification(scanOptions);
+
+    const paymentToken = ["mainnet", "polygon"].includes(paymentNetwork) ? "glm" : "tglm";
+    const paymentPlatform = `${paymentDriver}-${paymentNetwork}-${paymentToken}`;
 
     glm.market
-      .publishAndRefreshDemand(demandSpec)
+      .scan(scanSpecification)
       .pipe(
-        switchMap((demand) => glm.market.collectAllOfferProposals(demand)),
-        filter(scanningFilter),
-        scan((acc, proposal) => {
-          acc.push(proposal);
-          return acc;
-        }, [] as OfferProposal[]),
+        filter((offer) => priceFilter(offer)),
+        filter((offer) => providerIdFilter(offer.provider.id)),
+        filter((offer) => providerNameFilter(offer.provider.name)),
+        filter((offer) =>
+          providerWalletFilter(offer.properties[`golem.com.payment.platform.${paymentPlatform}.address`] as string),
+        ),
         takeUntil(timer(scanTime * 1000)),
-        last(),
+        toArray(),
       )
       .subscribe({
-        next: (proposals) => {
+        next: (offersFound) => {
           if (!options.silent) {
             console.log("Scan finished, here are the results");
-            console.log("Your market query was matched with %d proposals", proposals.length);
+            console.log("Your market query was matched with %d proposals", offersFound.length);
           }
 
-          const displayProposals = proposals.map((p) => {
-            const memory = p.getDto()["memory"];
-            const storage = p.getDto()["storage"];
+          const displayProposals = offersFound.map((offer) => {
+            const memory = offer.memory;
+            const storage = offer.storage;
             return {
-              providerId: p.provider.id,
-              providerName: p.provider.name,
-              startPrice: unifyPrice(p.pricing.start),
-              cpuPerHourPrice: unifyPrice(p.pricing.cpuSec * 3600),
-              envPerHourPrice: unifyPrice(p.pricing.envSec * 3600),
-              cpuCores: p.getDto()["cpuCores"],
-              cpuThreads: p.getDto()["cpuThreads"],
+              providerId: offer.provider.id,
+              providerName: offer.provider.name,
+              startPrice: unifyPrice(offer.pricing.start),
+              cpuPerHourPrice: unifyPrice(offer.pricing.cpuSec * 3600),
+              envPerHourPrice: unifyPrice(offer.pricing.envSec * 3600),
+              cpuCores: offer.cpuCores,
+              cpuThreads: offer.cpuThreads,
               memoryGib: memory ? parseFloat(memory.toFixed(1)) : "N/A",
               storageGib: storage ? parseFloat(storage.toFixed(1)) : "N/A",
             };

--- a/src/market/market.command.ts
+++ b/src/market/market.command.ts
@@ -1,5 +1,5 @@
 import { Command, Option } from "commander";
-import { GolemNetwork, MarketOrderSpec, OfferProposal, ProposalFilterFactory } from "@golem-sdk/golem-js";
+import { GolemNetwork, MarketOrderSpec, OfferProposal, OfferProposalFilterFactory } from "@golem-sdk/golem-js";
 import chalk from "chalk";
 import { switchMap, filter, scan, takeUntil, timer, last } from "rxjs";
 
@@ -134,7 +134,7 @@ marketCommand
       return;
     }
 
-    const priceLimiter = ProposalFilterFactory.limitPriceFilter({
+    const priceLimiter = OfferProposalFilterFactory.limitPriceFilter({
       start: maxStartPrice,
       cpuPerSec: maxCpuPerHourPrice / 3600,
       envPerSec: maxEnvPerHourPrice / 3600,
@@ -152,7 +152,6 @@ marketCommand
     const order: MarketOrderSpec = {
       demand: {
         subnetTag,
-        expirationSec: scanTime,
         workload: {
           imageTag,
           minCpuCores,
@@ -171,7 +170,7 @@ marketCommand
           maxEnvPerHourPrice,
           maxStartPrice,
         },
-        proposalFilter: scanningFilter,
+        offerProposalFilter: scanningFilter,
       },
     };
 
@@ -179,7 +178,7 @@ marketCommand
       budget: 0,
       expirationSec: scanTime,
     });
-    const demandSpec = await glm.market.buildDemandDetails(order.demand, allocation);
+    const demandSpec = await glm.market.buildDemandDetails(order.demand, order.market, allocation);
 
     glm.market
       .publishAndRefreshDemand(demandSpec)

--- a/src/new/new.action.ts
+++ b/src/new/new.action.ts
@@ -55,8 +55,12 @@ async function getTemplate(providedTemplate?: string): Promise<string> {
         { name: "ts-node-esm", hint: "TypeScript CLI application (ESM)" },
         { name: "js-node", hint: "Plain Javascript CLI application (CommonJS)" },
         { name: "js-node-esm", hint: "Plain Javascript CLI application (ESM)" },
-        { name: "react-js", hint: "React web application (with Vite and plain Javascript)" },
-        { name: "react-ts", hint: "React web application (with Vite and Typescript)" },
+        {
+          name: "(coming soon) react-js",
+          hint: "React web application (with Vite and plain Javascript)",
+          disabled: true,
+        },
+        { name: "(coming soon) react-ts", hint: "React web application (with Vite and Typescript)", disabled: true },
         // { name: "js-webapp", hint: "Plain Javascript Express based web application" },
       ],
     })) as { template: string };

--- a/src/run-on-golem/context-interface.ts
+++ b/src/run-on-golem/context-interface.ts
@@ -1,8 +1,0 @@
-import { WorkContext } from "@golem-sdk/golem-js";
-
-export interface ProgramContext {
-  exited: boolean;
-  workContext: WorkContext;
-  startDate: Date;
-  vars: { [key: string]: string | undefined };
-}

--- a/src/run-on-golem/run-on-golem.action.ts
+++ b/src/run-on-golem/run-on-golem.action.ts
@@ -282,27 +282,27 @@ export async function runOnGolemAction(files: string[], options: RunOnGolemOptio
 
   try {
     const order = await createMarketOrder(options);
-    const lease = await glm.oneOf({ order });
+    const rental = await glm.oneOf({ order });
     // force deploy activity on the provider
-    await lease.getExeUnit();
+    await rental.getExeUnit();
     context.metadata.activityStart = new Date();
 
     // Install process signal handlers.
-    installSignalHandlers(lease, glm, context);
+    installSignalHandlers(rental, glm, context);
 
     // Execute files.
     for (const file of files) {
-      await execFile(lease, context, file);
+      await execFile(rental, context, file);
     }
 
     // Execute commands from CLI
     if (options.execute) {
-      await execLine(lease, context, options.execute);
+      await execLine(rental, context, options.execute);
     }
 
     // Go to interactive shell if working in interactive mode.
     if ((!options.execute && !files.length) || options.interactive) {
-      await execConsole(lease, context);
+      await execConsole(rental, context);
     }
   } catch (e) {
     console.error(e);

--- a/src/run-on-golem/run-on-golem.action.ts
+++ b/src/run-on-golem/run-on-golem.action.ts
@@ -195,7 +195,6 @@ async function createMarketOrder(options: RunOnGolemOptions): Promise<MarketOrde
     console.log(`Publishing order using image ${options.image}`);
     return {
       demand: {
-        expirationSec: timeout,
         workload: {
           imageTag: options.image,
         },

--- a/src/run-on-golem/shell-program.ts
+++ b/src/run-on-golem/shell-program.ts
@@ -3,10 +3,10 @@ import { checkDirExists, checkFileExists } from "../lib/file";
 import path from "node:path";
 import { DateTime } from "luxon";
 import { writeFile } from "fs/promises";
-import { LeaseProcess } from "@golem-sdk/golem-js";
+import { ResourceRental } from "@golem-sdk/golem-js";
 import { ProcessContext } from "./shell-context";
 
-export function shellProgram(lease: LeaseProcess, processContext: ProcessContext): Command {
+export function shellProgram(rental: ResourceRental, processContext: ProcessContext): Command {
   const program = new Command("shell");
   program
     .exitOverride()
@@ -47,7 +47,7 @@ export function shellProgram(lease: LeaseProcess, processContext: ProcessContext
     .showHelpAfterError("Type `exit --help` form more information.")
     .helpOption(true)
     .action(() => {
-      void lease.finalize();
+      void rental.stopAndFinalize();
     });
 
   program
@@ -93,7 +93,7 @@ export function shellProgram(lease: LeaseProcess, processContext: ProcessContext
     .showHelpAfterError("Type `run --help` form more information.")
     .helpOption(true)
     .action(async (command: string, options) => {
-      const result = await lease.getExeUnit().then((exe) => exe.run(command));
+      const result = await rental.getExeUnit().then((exe) => exe.run(command));
       if (result.result !== "Ok") {
         console.error(`Command error: ${result.message}`);
       }
@@ -162,7 +162,7 @@ export function shellProgram(lease: LeaseProcess, processContext: ProcessContext
       }
 
       console.log(`Uploading ${sourceFile}...`);
-      const result = await lease.getExeUnit().then((exe) => exe.uploadFile(sourceFile, destinationFile));
+      const result = await rental.getExeUnit().then((exe) => exe.uploadFile(sourceFile, destinationFile));
       if (result.result === "Ok") {
         console.log("File uploaded.");
       } else {
@@ -191,7 +191,7 @@ export function shellProgram(lease: LeaseProcess, processContext: ProcessContext
       }
 
       console.log(`Downloading ${sourceFile}...`);
-      const result = await lease.getExeUnit().then((exe) => exe.downloadFile(sourceFile, destinationPath));
+      const result = await rental.getExeUnit().then((exe) => exe.downloadFile(sourceFile, destinationPath));
       if (result.result === "Ok") {
         console.log("File downloaded.");
       } else {


### PR DESCRIPTION
- Bump golem-js to stable 3.0
- Update tsconfigs to use more modern defaults
- Set the default rent hours in project templates to 15 minutes (providers have issues with demands with expiration <= 5 minutes) 
- Update market scan to use the new yagna endpoint instead of creating a demand